### PR TITLE
ISSUE #2: Resolved.

### DIFF
--- a/app/models/codimd_pad.rb
+++ b/app/models/codimd_pad.rb
@@ -5,7 +5,6 @@ class CodimdPad
   def self.pads(project)
     scope = CodimdNote.joins(:User)
                       .where('title is NOT NULL')
-                      .where('email is NOT NULL')
 
     scope = if project
               scope.where("permission!='private' OR email IN(:mails)", mails: User.current.mails)


### PR DESCRIPTION
Removes the condition of the query. This does not affect the whole query and checking the email address of the author still works even if the email address is `NULL`.

But it enables the plugin to work even if CodiMD is authenticated via SAML.